### PR TITLE
upgrade lending pool for refunding close Makai

### DIFF
--- a/contracts/protocol/lendingpool/LendingPool.sol
+++ b/contracts/protocol/lendingpool/LendingPool.sol
@@ -13,9 +13,7 @@ import {IFlashLoanReceiver} from '../../flashloan/interfaces/IFlashLoanReceiver.
 import {IPriceOracleGetter} from '../../interfaces/IPriceOracleGetter.sol';
 import {IStableDebtToken} from '../../interfaces/IStableDebtToken.sol';
 import {ILendingPool} from '../../interfaces/ILendingPool.sol';
-import {
-  VersionedInitializable
-} from '../libraries/starlay-upgradeability/VersionedInitializable.sol';
+import {VersionedInitializable} from '../libraries/starlay-upgradeability/VersionedInitializable.sol';
 import {Helpers} from '../libraries/helpers/Helpers.sol';
 import {Errors} from '../libraries/helpers/Errors.sol';
 import {WadRayMath} from '../libraries/math/WadRayMath.sol';
@@ -74,7 +72,7 @@ contract LendingPool is VersionedInitializable, ILendingPool, LendingPoolStorage
     );
   }
 
-  function getRevision() internal pure override returns (uint256) {
+  function getRevision() internal pure virtual override returns (uint256) {
     return LENDINGPOOL_REVISION;
   }
 
@@ -256,8 +254,9 @@ contract LendingPool is VersionedInitializable, ILendingPool, LendingPoolStorage
       variableDebt
     );
 
-    uint256 paybackAmount =
-      interestRateMode == DataTypes.InterestRateMode.STABLE ? stableDebt : variableDebt;
+    uint256 paybackAmount = interestRateMode == DataTypes.InterestRateMode.STABLE
+      ? stableDebt
+      : variableDebt;
 
     if (amount < paybackAmount) {
       paybackAmount = amount;
@@ -434,17 +433,16 @@ contract LendingPool is VersionedInitializable, ILendingPool, LendingPoolStorage
     address collateralManager = _addressesProvider.getLendingPoolCollateralManager();
 
     //solium-disable-next-line
-    (bool success, bytes memory result) =
-      collateralManager.delegatecall(
-        abi.encodeWithSignature(
-          'liquidationCall(address,address,address,uint256,bool)',
-          collateralAsset,
-          debtAsset,
-          user,
-          debtToCover,
-          receiveLToken
-        )
-      );
+    (bool success, bytes memory result) = collateralManager.delegatecall(
+      abi.encodeWithSignature(
+        'liquidationCall(address,address,address,uint256,bool)',
+        collateralAsset,
+        debtAsset,
+        user,
+        debtToCover,
+        receiveLToken
+      )
+    );
 
     require(success, Errors.LP_LIQUIDATION_CALL_FAILED);
 
@@ -859,10 +857,9 @@ contract LendingPool is VersionedInitializable, ILendingPool, LendingPoolStorage
 
     address oracle = _addressesProvider.getPriceOracle();
 
-    uint256 amountInETH =
-      IPriceOracleGetter(oracle).getAssetPrice(vars.asset).mul(vars.amount).div(
-        10**reserve.configuration.getDecimals()
-      );
+    uint256 amountInETH = IPriceOracleGetter(oracle).getAssetPrice(vars.asset).mul(vars.amount).div(
+      10**reserve.configuration.getDecimals()
+    );
 
     ValidationLogic.validateBorrow(
       vars.asset,

--- a/contracts/protocol/lendingpool/LendingPoolV4.sol
+++ b/contracts/protocol/lendingpool/LendingPoolV4.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import {LendingPool} from './LendingPool.sol';
+import {ILendingPoolAddressesProvider} from '../../interfaces/ILendingPoolAddressesProvider.sol';
+
+/**
+ * @title LendingPool contract
+ * @dev Main point of interaction with an Starlay protocol's market
+ * - Users can:
+ *   # Deposit
+ *   # Withdraw
+ *   # Borrow
+ *   # Repay
+ *   # Swap their loans between variable and stable rate
+ *   # Enable/disable their deposits as collateral rebalance stable rate borrow positions
+ *   # Liquidate positions
+ *   # Execute Flash Loans
+ * - To be covered by a proxy contract, owned by the LendingPoolAddressesProvider of the specific market
+ * - All admin functions are callable by the LendingPoolConfigurator contract defined also in the
+ *   LendingPoolAddressesProvider
+ * @author Starlay
+ **/
+contract LendingPoolV4 is LendingPool {
+  function getRevision() internal pure virtual override returns (uint256) {
+    return 0x4;
+  }
+}

--- a/contracts/protocol/lendingpool/RefundableLendingPool.sol
+++ b/contracts/protocol/lendingpool/RefundableLendingPool.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+pragma experimental ABIEncoderV2;
+
+import {LendingPool} from './LendingPool.sol';
+import {ILendingPoolAddressesProvider} from '../../interfaces/ILendingPoolAddressesProvider.sol';
+import {IERC20} from '../../dependencies/openzeppelin/contracts/IERC20.sol';
+
+/**
+ * @title LendingPool contract
+ * @dev Main point of interaction with an Starlay protocol's market
+ * pool admin can refund tokens from Leverager.
+ * @author Starlay
+ **/
+contract RefundableLendingPool is LendingPool {
+  function getRevision() internal pure virtual override returns (uint256) {
+    return 0x3;
+  }
+
+  address public immutable _leverager;
+
+  constructor(address leverager) public LendingPool() {
+    _leverager = leverager;
+  }
+
+  function refundFromLeverager(address token) external {
+    address poolAdmin = ILendingPoolAddressesProvider(_addressesProvider).getPoolAdmin();
+    require(msg.sender == poolAdmin, 'only pool admin');
+    uint256 balance = IERC20(token).balanceOf(_leverager);
+    if (balance > 0) {
+      IERC20(token).transferFrom(_leverager, poolAdmin, balance);
+    }
+  }
+}

--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -56,7 +56,7 @@ export const NETWORKS_DEFAULT_GAS: iParamsPerNetwork<number> = {
   [eEthereumNetwork.tenderly]: 1 * GWEI,
   [eAstarNetwork.shibuya]: 3 * GWEI,
   [eAstarNetwork.shiden]: 1 * GWEI,
-  [eAstarNetwork.astar]: 1 * GWEI,
+  [eAstarNetwork.astar]: 20 * GWEI,
 };
 
 export const BLOCK_TO_FORK: iParamsPerNetwork<number | undefined> = {

--- a/tasks/deployments/deploy-lendingPoolImpls.ts
+++ b/tasks/deployments/deploy-lendingPoolImpls.ts
@@ -1,0 +1,25 @@
+import { LendingPoolV4Factory } from './../../types/LendingPoolV4Factory';
+import { RefundableLendingPoolFactory } from './../../types/RefundableLendingPoolFactory';
+import { task } from 'hardhat/config';
+import {
+  deployStarlayLibraries,
+  deployUiIncentiveDataProviderV2,
+} from '../../helpers/contracts-deployments';
+import { eContractid } from '../../helpers/types';
+import { getFirstSigner } from '../../helpers/contracts-getters';
+
+task(`deploy-LendingPoolImpls`, `Deploys LendingPoolImpls`)
+  .addFlag('verify', 'Verify UiIncentiveDataProviderV2 contract via Etherscan API.')
+  .setAction(async ({ verify }, localBRE) => {
+    await localBRE.run('set-DRE');
+    if (!localBRE.network.config.chainId) {
+      throw new Error('INVALID_CHAIN_ID');
+    }
+    const libs = await deployStarlayLibraries();
+    const refundable = await new RefundableLendingPoolFactory(libs, await getFirstSigner()).deploy(
+      '0x5336C37c96B612749d019F86828885708f6BD10E'
+    );
+    console.log('refundable pool deployed at:', refundable.address);
+    const v4 = await new LendingPoolV4Factory(libs, await getFirstSigner()).deploy();
+    console.log('pool v4 deployed at:', v4.address);
+  });

--- a/tasks/deployments/deploy-lendingPoolImpls.ts
+++ b/tasks/deployments/deploy-lendingPoolImpls.ts
@@ -15,7 +15,10 @@ task(`deploy-LendingPoolImpls`, `Deploys LendingPoolImpls`)
     if (!localBRE.network.config.chainId) {
       throw new Error('INVALID_CHAIN_ID');
     }
-    const libs = await deployStarlayLibraries();
+    const libs = {
+      ['__$de8c0cf1a7d7c36c802af9a64fb9d86036$__']: '0xaCF53F9307A5B1616C7E35Fc0dEbd85e9925339A',
+      ['__$22cd43a9dda9ce44e9b92ba393b88fb9ac$__']: '0xa549A423BC2Aff1A566B644911C00c6Dc2F0390F',
+    };
     const refundable = await new RefundableLendingPoolFactory(libs, await getFirstSigner()).deploy(
       '0x5336C37c96B612749d019F86828885708f6BD10E'
     );

--- a/test-suites/test-starlay/upgrade-lending-pool.spec.ts
+++ b/test-suites/test-starlay/upgrade-lending-pool.spec.ts
@@ -1,0 +1,113 @@
+import { LendingPoolV4 } from './../../types/LendingPoolV4.d';
+import BigNumber from 'bignumber.js';
+import { APPROVAL_AMOUNT_LENDING_POOL, oneEther } from '../../helpers/constants';
+import { convertToCurrencyDecimals } from '../../helpers/contracts-helpers';
+import { DRE } from '../../helpers/misc-utils';
+import { ProtocolErrors, RateMode } from '../../helpers/types';
+import { makeSuite } from './helpers/make-suite';
+import { LendingPoolV4Factory, RefundableLendingPoolFactory } from '../../types';
+import { deployStarlayLibraries } from '../../helpers/contracts-deployments';
+import { getLendingPoolAddressesProvider } from '../../helpers/contracts-getters';
+import { parseEther } from 'ethers/lib/utils';
+
+const chai = require('chai');
+const { expect } = chai;
+
+makeSuite('LendingPool upgrade - lending pool upgrade', (testEnv) => {
+  it('can be upgraded', async () => {
+    const { dai, weth, usdc, deployer, users, pool, oracle, configurator } = testEnv;
+    const depositor = users[0];
+    const borrower = users[1];
+    const dummyLeverager = users[2];
+
+    await configurator.enableReserveStableRate(weth.address);
+    await configurator.enableReserveStableRate(usdc.address);
+
+    //mints DAI to depositor
+    await dai.connect(depositor.signer).mint(await convertToCurrencyDecimals(dai.address, '2000'));
+
+    //approve protocol to access depositor wallet
+    await dai.connect(depositor.signer).approve(pool.address, APPROVAL_AMOUNT_LENDING_POOL);
+
+    //mints DAI to dummyLeverager
+    await dai
+      .connect(dummyLeverager.signer)
+      .mint(await convertToCurrencyDecimals(dai.address, '2000'));
+
+    //approve protocol to access dummyLeverager wallet
+    await dai.connect(dummyLeverager.signer).approve(pool.address, parseEther('2000'));
+
+    //user 1 deposits 1000 DAI
+    const amountDAItoDeposit = await convertToCurrencyDecimals(dai.address, '1000');
+    await pool
+      .connect(depositor.signer)
+      .deposit(dai.address, amountDAItoDeposit, depositor.address, '0');
+
+    const amountETHtoDeposit = await convertToCurrencyDecimals(weth.address, '1');
+
+    //mints WETH to borrower
+    await weth.connect(borrower.signer).mint(amountETHtoDeposit);
+
+    //approve protocol to access borrower wallet
+    await weth.connect(borrower.signer).approve(pool.address, APPROVAL_AMOUNT_LENDING_POOL);
+
+    //user 2 deposits 1 WETH
+    await pool
+      .connect(borrower.signer)
+      .deposit(weth.address, amountETHtoDeposit, borrower.address, '0');
+
+    //user 2 borrows
+    const userGlobalData = await pool.getUserAccountData(borrower.address);
+    const daiPrice = await oracle.getAssetPrice(dai.address);
+
+    const amountDAIToBorrow = await convertToCurrencyDecimals(
+      dai.address,
+      new BigNumber(userGlobalData.availableBorrowsETH.toString())
+        .div(daiPrice.toString())
+        .multipliedBy(0.95)
+        .toFixed(0)
+    );
+
+    await pool
+      .connect(borrower.signer)
+      .borrow(dai.address, amountDAIToBorrow, RateMode.Variable, '0', borrower.address);
+
+    const userGlobalDataAfter = await pool.getUserAccountData(borrower.address);
+
+    expect(userGlobalDataAfter.currentLiquidationThreshold.toString()).to.be.bignumber.equal(
+      '8500',
+      'Invalid liquidation threshold'
+    );
+
+    // Upgrade lending pool to RefundableLendingPool
+    const libs = await deployStarlayLibraries();
+    const refundablePoolImpl = await new RefundableLendingPoolFactory(
+      await deployStarlayLibraries(),
+      deployer.signer
+    ).deploy(dummyLeverager.address);
+    const addressProvider = await getLendingPoolAddressesProvider();
+    addressProvider.connect(deployer.signer).setLendingPoolImpl(refundablePoolImpl.address);
+
+    // leverager can be deposited 1,000 DAI
+    const refundablePool = RefundableLendingPoolFactory.connect(pool.address, deployer.signer);
+    expect(await dai.balanceOf(dummyLeverager.address)).to.be.equal(parseEther('2000'));
+    const adminBalanceBefore = await dai.balanceOf(deployer.address);
+    await refundablePool.refundFromLeverager(dai.address);
+    expect(await dai.balanceOf(dummyLeverager.address)).to.be.equal(parseEther('0'));
+    const adminBalanceAfter = await dai.balanceOf(deployer.address);
+    expect(await adminBalanceAfter.sub(adminBalanceBefore)).to.be.equal(parseEther('2000'));
+
+    // Upgrade lending pool to LendingPoolV4
+    const poolV4 = await new LendingPoolV4Factory(libs, deployer.signer).deploy();
+    addressProvider.connect(deployer.signer).setLendingPoolImpl(poolV4.address);
+    // user 1 deposits more 1,000 DAI
+    await pool
+      .connect(depositor.signer)
+      .deposit(dai.address, amountDAItoDeposit, depositor.address, '0');
+    const borrowerData = await pool.getUserAccountData(borrower.address);
+    expect(userGlobalDataAfter.currentLiquidationThreshold.toString()).to.be.bignumber.equal(
+      '8500',
+      'Invalid liquidation threshold'
+    );
+  });
+});


### PR DESCRIPTION
Upgrade Lending Pool for refunding USDC and WETH deposits to each tx initiators:
- https://blockscout.com/astar/tx/0x2c8651aaae35589928f91fab17bfc56b014564da812e88039cb440603ee4a1b1
- https://blockscout.com/astar/tx/0x7359094822599ad2715306cde98a8a7620c6d4ac1ca7fcf97174f49d823a8dbd

After refunding completed, lending pool will be upgraded again to V4, which is without refund function from the Makai contract.

```
- Enviroment
  - Network : astar
refundable pool deployed at: 0xb1eD5d20D118f7F971c75bC84B350Be67D93cEDB
pool v4 deployed at: 0xFbBC96E9FfEC5b127876e9B4166598294b8B39f2
```


```
- Enviroment
  - Network : shiden
refundable pool deployed at: 0xC05b29F680209acc63Dfe818307E3d83516688D9
pool v4 deployed at: 0xA6032D5787Dcd8789C230966ba358aa17147CC27
```