### PR TITLE
topic/ltoken rev3 & upgrade native-usdt

### DIFF
--- a/contracts/protocol/tokenization/LTokenRev3.sol
+++ b/contracts/protocol/tokenization/LTokenRev3.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.6.12;
+
+import "./LTokenRev2.sol";
+
+/**
+ * @title Starlay ERC20 LToken Rev3
+ * @dev Implementation of the interest bearing token for the Starlay protocol
+ * @author Starlay
+ */
+contract LTokenRev3 is LTokenRev2 {
+  uint256 public constant LTOKEN_REVISION_3 = 0x3;
+
+  /// @inheritdoc VersionedInitializable
+  function getRevision() internal pure virtual override returns (uint256) {
+    return LTOKEN_REVISION_3;
+  }
+}

--- a/helpers/contracts-deployments.ts
+++ b/helpers/contracts-deployments.ts
@@ -13,6 +13,7 @@ import {
   LendingRateOracleFactory,
   LTokenFactory,
   LTokenRev2Factory,
+  LTokenRev3Factory,
   LTokensAndRatesHelperFactory,
   MintableDelegationERC20Factory,
   MintableERC20Factory,
@@ -442,6 +443,16 @@ export const deployGenericLTokenRev2Impl = async (verify: boolean) =>
 export const deployGenericLTokenRev2ImplWithSigner = async (verify: boolean, signer: Signer) =>
   withSaveAndVerify(await new LTokenRev2Factory(signer).deploy(), eContractid.LToken, [], verify);
 
+export const deployGenericLTokenRev3Impl = async (verify: boolean) => withSaveAndVerify(
+  await new LTokenRev3Factory(await getFirstSigner()).deploy(),
+  eContractid.LToken,
+  [],
+  verify
+);
+
+export const deployGenericLTokenRev3ImplWithSigner = async (verify: boolean, signer: Signer) =>
+  withSaveAndVerify(await new LTokenRev3Factory(signer).deploy(), eContractid.LToken, [], verify);
+
 export const deployDelegationAwareLToken = async (
   [pool, underlyingAssetAddress, treasuryAddress, incentivesController, name, symbol]: [
     tEthereumAddress,
@@ -619,7 +630,6 @@ export const deploySelfdestructTransferMock = async (verify?: boolean) =>
 export const chooseLTokenDeployment = (id: eContractid) => {
   switch (id) {
     case eContractid.LToken:
-      // return deployGenericLTokenImpl;
       return deployGenericLTokenRev2Impl; // use Rev2
     case eContractid.DelegationAwareLToken:
       return deployDelegationAwareLTokenImpl;

--- a/tasks/operations/upgrade-ltokens-to-rev3.ts
+++ b/tasks/operations/upgrade-ltokens-to-rev3.ts
@@ -103,7 +103,7 @@ const PARAMS_TO_UPGRADE = {
     asset: "0xfFFfffFF000000000000000000000001000007C0",
     ltoken: "0x659110D07923e2C3fCB9d3C9E66B0a1605e7ce71",
   },
-  newLtokenImpl: ""
+  newLtokenImpl: "0x892DEF735c209b191Ac914e5a4286629FcBF9082"
 }
 task(
   'upgrade-ltoken-to-rev3-by-deployed-ltokens',

--- a/tasks/operations/upgrade-ltokens-to-rev3.ts
+++ b/tasks/operations/upgrade-ltokens-to-rev3.ts
@@ -1,0 +1,152 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { formatEther } from 'ethers/lib/utils';
+import { task } from 'hardhat/config';
+import { ConfigNames, loadPoolConfig } from '../../helpers/configuration';
+import {
+  deployGenericLTokenRev3ImplWithSigner,
+} from '../../helpers/contracts-deployments';
+import {
+  getLendingPoolConfiguratorProxy,
+  getStarlayProtocolDataProvider,
+} from '../../helpers/contracts-getters';
+import { getParamPerNetwork } from '../../helpers/contracts-helpers';
+import { getLTokenExtraParams } from '../../helpers/init-helpers';
+import { setDRE } from '../../helpers/misc-utils';
+import { eContractid, eNetwork } from '../../helpers/types';
+import { LendingPoolConfigurator } from '../../types';
+
+const SUPPORTED_NETWORK = ['astar', 'shiden', 'localhost'] as const;
+type SupportedNetwork = typeof SUPPORTED_NETWORK[number];
+type EthereumAddress = `0x${string}`;
+
+type Addresses = {
+  StarlayProtocolDataProvider: EthereumAddress;
+  LendingPoolConfigurator: EthereumAddress;
+  IncentiveController: EthereumAddress;
+  Voter: EthereumAddress | '';
+};
+type Constants = {
+  [key in SupportedNetwork]?: Addresses;
+};
+const astar: Addresses = {
+  StarlayProtocolDataProvider: '0x5BF9B2644E273D92ff1C31A83476314c95953133',
+  LendingPoolConfigurator: '0xa1c2ED9e0d09f5e441aC9C44AFa308D38dAf463c',
+  IncentiveController: '0x97Ab79B80E8904214413D8219E8B04373D1030AD',
+  Voter: '0xB45Ae34e16D97D87c021DAf03a15142935cFB177',
+};
+const shiden: Addresses = {
+  StarlayProtocolDataProvider: '0x3fD308785Cf41F30993038c145cE50b7fF677a71',
+  LendingPoolConfigurator: '0x1aE33143380567fe1246bE4Be5008B7bFa25790A',
+  IncentiveController: '0xD9F3bbC743b7AF7E1108653Cd90E483C03D6D699',
+  Voter: '0x04f6A8eF63CC99Db088e036CeC627cea9941E250',
+};
+const CONSTANTS: Constants = {
+  astar: astar,
+  shiden: shiden,
+};
+const EOA = ''; // set PoolAdmin
+
+// deploy-ltoken-rev3
+task("deploy-ltoken-rev3", "deploy-ltoken-rev3").setAction(async ({}, localBRE) => {
+  if (!(SUPPORTED_NETWORK as ReadonlyArray<string>).includes(localBRE.network.name))
+    throw new Error(`Support only ${SUPPORTED_NETWORK} ...`);
+  setDRE(localBRE);
+  const { ethers } = localBRE;
+  const network = <eNetwork>localBRE.network.name;
+  const signer = await ethers.getSigner(EOA);
+
+  console.log(`network: ${network}`);
+  console.log(`signer: ${signer.address}`);
+  console.log(`balance (before): ${formatEther(await signer.getBalance())}`);
+  console.log(`- - - - - - - - - - -`);
+
+  const instance = await deployGenericLTokenRev3ImplWithSigner(false, signer);
+  console.log(`contract address ... ${instance.address}`);
+
+  console.log(`- - - - - - - - - - -`);
+  console.log(`balance (after): ${formatEther(await signer.getBalance())}`);
+})
+
+// upgrade-ltoken-to-rev3-by-deployed-ltokens
+//// utilities
+type UpdateLTokenInputParams = {
+  asset: string;
+  treasury: string;
+  incentivesController: string;
+  name: string;
+  symbol: string;
+  implementation: string;
+  params: string;
+};
+const upgradeLTokenWithDeployedLTokenRev3 = async (
+  signer: SignerWithAddress,
+  configurator: LendingPoolConfigurator,
+  updateLTokenInputParams: Omit<UpdateLTokenInputParams, 'implementation'>,
+  implAddress: string
+) => {
+  console.log(`implAddress ... ${implAddress}`);
+
+  console.log(`> upgrade ltoken`);
+  const _updateLTokenInputParams = {
+    ...updateLTokenInputParams,
+    implementation: implAddress,
+  };
+  const tx = await configurator.connect(signer).updateLToken(_updateLTokenInputParams);
+  console.log(`tx hash: ${tx.hash}`);
+  await tx.wait();
+  console.log(`>> end: upgrade ltoken`);
+};
+//// main
+const PARAMS_TO_UPGRADE = {
+  target: {
+    symbol: "AUSD",
+    asset: "0xfFFFFfFF00000000000000010000000000000001",
+    ltoken: "0x4aaD525895373ad3D8C4aF4743723436312F30e7",
+  },
+  newLtokenImpl: ""
+}
+task(
+  'upgrade-ltoken-to-rev3-by-deployed-ltokens',
+  'upgrade-ltoken-to-rev3-by-deployed-ltokens'
+).setAction(async ({}, localBRE) => {
+  if (!(SUPPORTED_NETWORK as ReadonlyArray<string>).includes(localBRE.network.name))
+    throw new Error(`Support only ${SUPPORTED_NETWORK} ...`);
+  setDRE(localBRE);
+  const { ethers } = localBRE;
+  const network = <eNetwork>localBRE.network.name;
+  const constants = CONSTANTS[network];
+  const pConf = loadPoolConfig(ConfigNames.Starlay);
+  const protocolDataProvider = await getStarlayProtocolDataProvider(
+    constants.StarlayProtocolDataProvider
+  );
+
+  const _signer = await ethers.getSigner(EOA);
+  console.log(`> signer ... ${_signer.address}`);
+
+  const symbolAndAddrs = getParamPerNetwork(pConf.ReserveAssets, network as eNetwork);
+  const { target, newLtokenImpl } = PARAMS_TO_UPGRADE
+  const assetAddress = symbolAndAddrs[target.symbol]
+  if (assetAddress.toLowerCase() != target.asset.toLowerCase()) throw new Error("Not equal input asset address to getted asset address")
+  const { lTokenAddress } = await protocolDataProvider.getReserveTokensAddresses(assetAddress);
+  if (lTokenAddress.toLowerCase() != target.ltoken.toLowerCase()) throw new Error("Not equal input ltoken address to getted ltoken address")
+
+  // generate params to use upgrading
+  const configurator = await getLendingPoolConfiguratorProxy(constants.LendingPoolConfigurator);
+  const { LTokenNamePrefix, SymbolPrefix } = pConf;
+  const updateLTokenInputParams: Omit<UpdateLTokenInputParams, 'implementation'> = {
+    asset: assetAddress,
+    treasury: constants.Voter, // purpose (change from treasury to voter for ve overall)
+    incentivesController: constants.IncentiveController,
+    name: `${LTokenNamePrefix} ${target.symbol}`,
+    symbol: `l${SymbolPrefix}${target.symbol}`,
+    // implementation: "0xTBD", // set when upgrading
+    params: await getLTokenExtraParams(eContractid.LToken, '0xTBD'),
+  };
+  // upgrade
+  await upgradeLTokenWithDeployedLTokenRev3(
+    _signer,
+    configurator,
+    updateLTokenInputParams,
+    newLtokenImpl
+  );
+})

--- a/tasks/operations/upgrade-ltokens-to-rev3.ts
+++ b/tasks/operations/upgrade-ltokens-to-rev3.ts
@@ -99,9 +99,9 @@ const upgradeLTokenWithDeployedLTokenRev3 = async (
 //// main
 const PARAMS_TO_UPGRADE = {
   target: {
-    symbol: "AUSD",
-    asset: "0xfFFFFfFF00000000000000010000000000000001",
-    ltoken: "0x4aaD525895373ad3D8C4aF4743723436312F30e7",
+    symbol: "NativeUSDT",
+    asset: "0xfFFfffFF000000000000000000000001000007C0",
+    ltoken: "0x659110D07923e2C3fCB9d3C9E66B0a1605e7ce71",
   },
   newLtokenImpl: ""
 }

--- a/test-suites/test-starlay/upgrade-ltoken.spec.ts
+++ b/test-suites/test-starlay/upgrade-ltoken.spec.ts
@@ -1,10 +1,10 @@
 import { expect } from 'chai';
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { deployGenericLTokenImpl, deployGenericLTokenRev2Impl } from '../../helpers/contracts-deployments';
+import { deployGenericLTokenImpl, deployGenericLTokenRev2Impl, deployGenericLTokenRev3Impl } from '../../helpers/contracts-deployments';
 import { getLTokenExtraParams } from '../../helpers/init-helpers';
 import { createRandomAddress, DRE } from '../../helpers/misc-utils';
 import { eContractid } from '../../helpers/types';
-import { LendingPool, LendingPoolConfigurator, LToken, LTokenFactory, LTokenRev2, LTokenRev2Factory, MintableERC20 } from '../../types';
+import { LendingPool, LendingPoolConfigurator, LToken, LTokenFactory, LTokenRev2, LTokenRev2Factory, LTokenRev3Factory, MintableERC20 } from '../../types';
 import { makeSuite, TestEnv } from './helpers/make-suite';
 
 type UpdateLTokenInputParams = {
@@ -23,6 +23,7 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
     let _lendingPool: LendingPool
     let _dai: MintableERC20
     let _lDaiAddress: string
+
     before(async () => {
       const { configurator, pool, dai, lDai } = testEnv;
       _configurator = configurator;
@@ -30,40 +31,78 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
       _dai = dai;
       _lDaiAddress = lDai.address;
     })
-    it("fail if using implementation of the same version to deployed", async () => {
+    it("Prerequisite", async () => {
       const hre = DRE as HardhatRuntimeEnvironment;
       const reserveData = await _lendingPool.getReserveData(_dai.address)
-      expect(reserveData.lTokenAddress.toLowerCase()).to.eq(_lDaiAddress.toLowerCase())
-      const lDaiProxy = LTokenFactory.connect(reserveData.lTokenAddress, hre.ethers.provider)
+      const lDaiProxy = LTokenRev2Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
 
-      const newLTokenImpl = await deployGenericLTokenImpl(false)
-      console.log(`newLTokenImpl ... ${newLTokenImpl.address}`)
-
-      const updateLTokenInputParams: UpdateLTokenInputParams = {
-        asset: _dai.address,
-        treasury: createRandomAddress(),
-        incentivesController: createRandomAddress(),
-        name: "Starlay interest bearing DAI UPDATED",
-        symbol: "lDAI UPDATIED",
-        implementation: newLTokenImpl.address,
-        params: await getLTokenExtraParams(eContractid.LToken, _dai.address),
-      };
-
-      await expect(_configurator.updateLToken(updateLTokenInputParams)).to.reverted
-      const [name, symbol] = await Promise.all([
+      const [name, symbol, decimals, underlyingAsset, revision] = await Promise.all([
         lDaiProxy.name(),
         lDaiProxy.symbol(),
+        lDaiProxy.decimals(),
+        lDaiProxy.UNDERLYING_ASSET_ADDRESS(),
+        lDaiProxy.getCurrentRevision()
+      ])
+      expect(name).to.eq("Starlay interest bearing DAI")
+      expect(symbol).to.eq("lDAI")
+      expect(decimals).to.eq(18)
+      expect(underlyingAsset.toLowerCase()).to.eq(_dai.address.toLowerCase())
+      expect(revision.toNumber()).to.eq(2)
+    })
+    const generateUpdateLTokenInputParams = async (newLTokenImplAddress: string): Promise<UpdateLTokenInputParams> => ({
+      asset: _dai.address,
+      treasury: createRandomAddress(),
+      incentivesController: createRandomAddress(),
+      name: "Starlay interest bearing DAI UPDATED",
+      symbol: "lDAI UPDATED",
+      implementation: newLTokenImplAddress,
+      params: await getLTokenExtraParams(eContractid.LToken, _dai.address),
+    })
+    it("fail if using lower version implementation", async () => {
+      const hre = DRE as HardhatRuntimeEnvironment;
+      const reserveData = await _lendingPool.getReserveData(_dai.address)
+      const lDaiProxy = LTokenRev2Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
+
+      const newLTokenImpl = await deployGenericLTokenImpl(false)
+
+      const updateLTokenInputParams = await generateUpdateLTokenInputParams(newLTokenImpl.address)
+      await expect(_configurator.updateLToken(updateLTokenInputParams)).to.reverted
+
+      const [name, symbol, currentVersion] = await Promise.all([
+        lDaiProxy.name(),
+        lDaiProxy.symbol(),
+        lDaiProxy.getCurrentRevision()
       ])
       expect(name).not.to.eq("Starlay interest bearing DAI UPDATED")
       expect(symbol).not.to.eq("lDAI UPDATIED")
+      expect(currentVersion.toNumber()).to.eq(2)
+    })
+    it("fail if using same version implementation", async () => {
+      const hre = DRE as HardhatRuntimeEnvironment;
+      const reserveData = await _lendingPool.getReserveData(_dai.address)
+      const lDaiProxy = LTokenRev2Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
+
+      const newLTokenImpl = await deployGenericLTokenRev2Impl(false)
+
+      const updateLTokenInputParams = await generateUpdateLTokenInputParams(newLTokenImpl.address)
+      await expect(_configurator.updateLToken(updateLTokenInputParams)).to.reverted
+
+      const [name, symbol, currentVersion] = await Promise.all([
+        lDaiProxy.name(),
+        lDaiProxy.symbol(),
+        lDaiProxy.getCurrentRevision()
+      ])
+      expect(name).not.to.eq("Starlay interest bearing DAI UPDATED")
+      expect(symbol).not.to.eq("lDAI UPDATIED")
+      expect(currentVersion.toNumber()).to.eq(2)
     })
     it("success", async () => {
       const hre = DRE as HardhatRuntimeEnvironment;
       const reserveData = await _lendingPool.getReserveData(_dai.address)
       expect(reserveData.lTokenAddress.toLowerCase()).to.eq(_lDaiAddress.toLowerCase())
 
-      const lDaiProxy = LTokenFactory.connect(reserveData.lTokenAddress, hre.ethers.provider)
-      const _lDaiProxy = LTokenRev2Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
+      const lDaiProxy = LTokenRev2Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
+      const _lDaiProxy = LTokenRev3Factory.connect(reserveData.lTokenAddress, hre.ethers.provider)
 
       const [name, symbol, decimals, underlyingAsset, pool, treasury, incentivesController, scaledTotalSupply, revision] = await Promise.all([
         lDaiProxy.name(),
@@ -74,20 +113,19 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
         lDaiProxy.RESERVE_TREASURY_ADDRESS(),
         lDaiProxy.getIncentivesController(),
         lDaiProxy.scaledTotalSupply(),
-        lDaiProxy.LTOKEN_REVISION(),
+        lDaiProxy.getCurrentRevision(),
       ])
       expect(name).to.eq("Starlay interest bearing DAI")
       expect(symbol).to.eq("lDAI")
       expect(decimals).to.eq(18)
       expect(underlyingAsset.toLowerCase()).to.eq(_dai.address.toLowerCase())
-      expect(revision.toNumber()).to.eq(1)
+      expect(revision.toNumber()).to.eq(2)
 
-      const newLTokenImpl = await deployGenericLTokenRev2Impl(false)
-      console.log(`newLTokenImpl ... ${newLTokenImpl.address}`)
+      const newLTokenImpl = await deployGenericLTokenRev3Impl(false)
 
       const _treasuryArg = createRandomAddress();
       const _incentivesControllerArg = createRandomAddress();
-      const _nameArg = `${name} V2`
+      const _nameArg = `${name} V3`
       const updateLTokenInputParams: UpdateLTokenInputParams = {
         asset: _dai.address,
         treasury: _treasuryArg,
@@ -104,7 +142,7 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
         newLTokenImpl.address
       )
 
-      const [_name, _symbol, _decimals, _underlyingAsset, _pool, _treasury, _incentivesController, _scaledTotalSupply, _revision, _REVISION] = await Promise.all([
+      const [_name, _symbol, _decimals, _underlyingAsset, _pool, _treasury, _incentivesController, _scaledTotalSupply, _revision] = await Promise.all([
         _lDaiProxy.name(),
         _lDaiProxy.symbol(),
         _lDaiProxy.decimals(),
@@ -114,9 +152,8 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
         _lDaiProxy.getIncentivesController(),
         _lDaiProxy.scaledTotalSupply(),
         _lDaiProxy.getCurrentRevision(),
-        _lDaiProxy.LTOKEN_REVISION_2(),
       ])
-      expect(_name).to.eq("Starlay interest bearing DAI V2")
+      expect(_name).to.eq("Starlay interest bearing DAI V3")
       expect(_symbol).to.eq(symbol)
       expect(_decimals).to.eq(decimals)
       expect(_underlyingAsset.toLowerCase()).to.eq(underlyingAsset.toLowerCase())
@@ -126,8 +163,7 @@ makeSuite("upgrade-ltoken", (testEnv: TestEnv) => {
       expect(_treasury.toLowerCase()).to.not.eq(treasury.toLowerCase())
       expect(_incentivesController).to.eq(_incentivesControllerArg)
       expect(_incentivesController.toLowerCase()).to.not.eq(incentivesController.toLowerCase())
-      expect(_revision.toNumber()).to.eq(2)
-      expect(_REVISION.toNumber()).to.eq(2)
+      expect(_revision.toNumber()).to.eq(3)
     })
   })
 })


### PR DESCRIPTION
```bash
yarn hardhat deploy-ltoken-rev3 --network xxx
yarn hardhat upgrade-ltoken-to-rev3-by-deployed-ltokens --network xxx
```

about native-usdt

```bash
> signer ... ...
LToken
implAddress ... 0x892DEF735c209b191Ac914e5a4286629FcBF9082
> upgrade ltoken
tx hash: 0x7917a46e3b1dcab047e517979b748f70d1049000141ff16ad6e064e974fb1b38
>> end: upgrade ltoken
```

```bash
## symbol: NativeUSDT
asset: 0xfFFfffFF000000000000000000000001000007C0
ltoken: 0x659110D07923e2C3fCB9d3C9E66B0a1605e7ce71
{
  name: 'Starlay interest bearing NativeUSDT',
  symbol: 'lNativeUSDT',
  decimals: 6,
  revision: 3,
  underlyingAsset: '0xfFFfffFF000000000000000000000001000007C0',
  pool: '0x90384334333f3356eFDD5b20016350843b90f182',
  incentivesController: '0x97Ab79B80E8904214413D8219E8B04373D1030AD',
  treasury: '0xB45Ae34e16D97D87c021DAf03a15142935cFB177',
  scaledTotalSupply: '1.319871'
}
```
